### PR TITLE
Update release workflow to support Homebrew and Chocolatey

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,13 +84,16 @@ jobs:
           # Update tauri.conf.json
           sed -i "s/\"version\": \".*\"/\"version\": \"$NEW_VERSION\"/" src-tauri/tauri.conf.json
 
+          # Update Chocolatey nuspec version
+          sed -i "s/<version>.*<\/version>/<version>$NEW_VERSION<\/version>/" packages/chocolatey/pisum-langue.nuspec
+
           # Update Cargo.lock
           cd src-tauri && cargo generate-lockfile && cd ..
 
       - name: Commit and tag
         run: |
           VERSION="${{ steps.bump.outputs.version }}"
-          git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
+          git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json packages/chocolatey/pisum-langue.nuspec
           git commit -m "chore: bump version to $VERSION"
           git tag -a "v$VERSION" -m "Release v$VERSION"
           git push origin main
@@ -132,8 +135,8 @@ jobs:
 
             **macOS (Homebrew) - Recommended:**
             ```bash
-            brew tap mschnecke/langue
-            brew install --cask langue
+            brew tap mschnecke/pisum-langue
+            brew install --cask pisum-langue
             ```
 
             **macOS (Direct Download):**
@@ -141,8 +144,7 @@ jobs:
 
             **Windows (Chocolatey):**
             ```powershell
-            choco source add -n="pisum-langue" -s="https://www.myget.org/F/mschnecke/api/v3/index.json"
-            choco install pisum-langue
+            choco install pisum-langue --source https://www.myget.org/F/mschnecke/api/v3/index.json
             ```
 
             **Windows (Direct Download):**
@@ -280,7 +282,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          repository: mschnecke/homebrew-lange
+          repository: mschnecke/homebrew-pisum-langue
           event-type: update-cask
           client-payload: '{"version": "${{ needs.create-release.outputs.version }}"}'
 

--- a/docs/IMPL-package-manager-distribution.md
+++ b/docs/IMPL-package-manager-distribution.md
@@ -1,0 +1,380 @@
+# Implementation Plan: Package Manager Distribution (Homebrew & Chocolatey)
+
+> Generated from: `docs/PRD-package-manager-distribution.md`
+> Date: 2026-03-14
+
+## 1. Overview
+
+This plan adds Homebrew (macOS) and Chocolatey (Windows) package manager support for Pisum Langue. The implementation creates the necessary package definitions, a Homebrew template cask, and wires everything into the existing `release.yml` workflow so that every release automatically publishes updated packages.
+
+The reference implementation at `/Users/mschnecke/workspace/github-global-hotkey` provides proven patterns for all components. The current `release.yml` already has `update-homebrew` and `update-chocolatey` jobs stubbed out — this plan fills in the missing package files and fixes issues in the workflow.
+
+## 2. Architecture & Design
+
+### Package Distribution Flow
+
+```
+release.yml (workflow_dispatch)
+  │
+  ├─ bump-version ──► Updates package.json, Cargo.toml, tauri.conf.json, pisum-langue.nuspec
+  │
+  ├─ create-release ──► Creates draft GitHub Release
+  │
+  ├─ build-tauri ──► Builds .pkg (macOS) and .msi (Windows), uploads to release
+  │
+  ├─ publish-release ──► Marks release as non-draft
+  │
+  ├─ update-homebrew ──► repository-dispatch → mschnecke/homebrew-pisum-langue
+  │                        └─ Tap workflow: downloads .pkg, computes SHA256, updates cask, commits
+  │
+  └─ update-chocolatey ──► Downloads .msi, computes SHA256, updates install script + nuspec,
+                            packs .nupkg, pushes to MyGet
+```
+
+### Repository Structure
+
+```
+Main repo (mschnecke/langue):
+  packages/
+  ├── homebrew/
+  │   └── pisum-langue.rb        ← Template cask (placeholder version/SHA)
+  └── chocolatey/
+      ├── pisum-langue.nuspec    ← Package metadata
+      └── tools/
+          ├── chocolateyinstall.ps1    ← Install script
+          └── chocolateyuninstall.ps1  ← Uninstall script
+
+Tap repo (mschnecke/homebrew-pisum-langue):
+  Casks/
+  └── pisum-langue.rb            ← Live cask (auto-updated by workflow)
+  .github/workflows/
+  └── update-cask.yml            ← Receives dispatch, updates cask
+```
+
+## 3. Phases & Milestones
+
+### Phase 1: Chocolatey Package Files
+**Goal:** Create the Chocolatey package definition files in the main repo.
+**Deliverable:** `packages/chocolatey/` directory with nuspec, install, and uninstall scripts ready for CI consumption.
+
+### Phase 2: Homebrew Cask Template
+**Goal:** Create the template Homebrew cask in the main repo.
+**Deliverable:** `packages/homebrew/pisum-langue.rb` with placeholder values.
+
+### Phase 3: Release Workflow Fixes
+**Goal:** Fix the existing `release.yml` to correctly reference files and update the nuspec during version bumps.
+**Deliverable:** Working `bump-version` and `update-homebrew` jobs with correct paths and repository name.
+
+### Phase 4: Homebrew Tap Repository
+**Goal:** Set up the `mschnecke/homebrew-pisum-langue` repository with cask and update workflow.
+**Deliverable:** Tap repo with `Casks/pisum-langue.rb` and `update-cask.yml` workflow.
+
+### Phase 5: Release Body Update
+**Goal:** Fix the release body installation instructions to match the PRD's prescribed commands.
+**Deliverable:** Updated release body template in `release.yml` with correct Homebrew and Chocolatey commands.
+
+## 4. Files Overview
+
+### Files to Create
+| File Path | Purpose |
+|-----------|---------|
+| `packages/chocolatey/pisum-langue.nuspec` | Chocolatey package metadata |
+| `packages/chocolatey/tools/chocolateyinstall.ps1` | Downloads and installs MSI from GitHub Releases |
+| `packages/chocolatey/tools/chocolateyuninstall.ps1` | Uninstalls MSI via registry lookup |
+| `packages/homebrew/pisum-langue.rb` | Template Homebrew cask with placeholder version/SHA256 |
+
+### Files in Tap Repository (mschnecke/homebrew-pisum-langue)
+| File Path | Purpose |
+|-----------|---------|
+| `Casks/pisum-langue.rb` | Live Homebrew cask formula |
+| `.github/workflows/update-cask.yml` | Receives dispatch, updates cask with new version |
+
+### Files to Modify
+| File Path | What Changes |
+|-----------|-------------|
+| `.github/workflows/release.yml` | Fix homebrew repo name, add nuspec to bump-version, update release body |
+
+## 5. Task Breakdown
+
+### Phase 1: Chocolatey Package Files
+
+#### Task 1.1: Create `packages/chocolatey/pisum-langue.nuspec`
+
+- **Files to create:**
+  - `packages/chocolatey/pisum-langue.nuspec` — Package metadata adapted from reference repo
+- **Implementation details:**
+  - Adapt from `/Users/mschnecke/workspace/github-global-hotkey/packages/chocolatey/global-hotkey.nuspec`
+  - Key fields:
+    ```xml
+    <id>pisum-langue</id>
+    <version>0.1.7</version>
+    <title>Pisum Langue</title>
+    <authors>Pisum Langue Team</authors>
+    <owners>mschnecke</owners>
+    <projectUrl>https://github.com/mschnecke/langue</projectUrl>
+    <description>AI-driven transcription utility. Hold a hotkey to record speech, release to transcribe and paste.</description>
+    <tags>transcription dictation speech-to-text ai hotkey</tags>
+    <releaseNotes>https://github.com/mschnecke/langue/releases</releaseNotes>
+    <packageSourceUrl>https://github.com/mschnecke/langue/tree/main/packages/chocolatey</packageSourceUrl>
+    ```
+- **Dependencies:** None
+- **Acceptance criteria:** Valid nuspec XML that `choco pack` can parse
+
+#### Task 1.2: Create `packages/chocolatey/tools/chocolateyinstall.ps1`
+
+- **Files to create:**
+  - `packages/chocolatey/tools/chocolateyinstall.ps1` — Install script
+- **Implementation details:**
+  - Adapt from reference repo's `chocolateyinstall.ps1`
+  - Key values:
+    ```powershell
+    $packageName = 'pisum-langue'
+    $packageArgs = @{
+      packageName    = $packageName
+      fileType       = 'msi'
+      url64bit       = 'https://github.com/mschnecke/langue/releases/download/v0.1.7/Pisum.Langue_0.1.7_x64_en-US.msi'
+      softwareName   = 'Pisum Langue*'
+      checksum64     = 'REPLACE_WITH_ACTUAL_CHECKSUM'
+      checksumType64 = 'sha256'
+      silentArgs     = '/qn /norestart'
+      validExitCodes = @(0, 3010, 1641)
+    }
+    Install-ChocolateyPackage @packageArgs
+    ```
+  - The `url64bit` and `checksum64` are placeholders — they get replaced by the `update-chocolatey` job in CI
+- **Dependencies:** None
+- **Acceptance criteria:** Script follows `Install-ChocolateyPackage` pattern with SHA256 checksum verification
+
+#### Task 1.3: Create `packages/chocolatey/tools/chocolateyuninstall.ps1`
+
+- **Files to create:**
+  - `packages/chocolatey/tools/chocolateyuninstall.ps1` — Uninstall script
+- **Implementation details:**
+  - Adapt from reference repo's `chocolateyuninstall.ps1`
+  - Searches registry at:
+    - `HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*`
+    - `HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*`
+  - Matches `softwareName` = `'Pisum Langue*'`
+  - Uses `Uninstall-ChocolateyPackage` with the MSI product code from registry
+  - Silent args: `/qn /norestart`
+- **Dependencies:** None
+- **Acceptance criteria:** Script correctly looks up and removes the MSI via registry ProductCode
+
+### Phase 2: Homebrew Cask Template
+
+#### Task 2.1: Create `packages/homebrew/pisum-langue.rb`
+
+- **Files to create:**
+  - `packages/homebrew/pisum-langue.rb` — Template cask formula
+- **Implementation details:**
+  - Adapt from reference repo's `packages/homebrew/global-hotkey.rb`
+  - aarch64 only (no Intel/universal — per PRD non-goals)
+  - Key structure:
+    ```ruby
+    cask "pisum-langue" do
+      version "0.1.7"
+      sha256 "REPLACE_WITH_ACTUAL_CHECKSUM"
+
+      url "https://github.com/mschnecke/langue/releases/download/v#{version}/Pisum.Langue_#{version}_aarch64.pkg"
+      name "Pisum Langue"
+      desc "AI-driven transcription utility"
+      homepage "https://github.com/mschnecke/langue"
+
+      depends_on macos: ">= :catalina"
+
+      pkg "Pisum.Langue_#{version}_aarch64.pkg"
+
+      uninstall pkgutil: "com.pisum.langue.app"
+
+      zap trash: [
+        "~/Library/Application Support/com.pisum.langue",
+        "~/Library/Caches/com.pisum.langue",
+        "~/Library/Preferences/com.pisum.langue.plist",
+        "~/Library/LaunchAgents/com.pisum.langue.plist",
+      ]
+    end
+    ```
+  - Version and SHA256 are placeholders in this template — the tap repo holds the live version
+- **Dependencies:** None
+- **Acceptance criteria:** Valid Ruby cask syntax with `zap` stanza covering all four paths from PRD requirement 4
+
+### Phase 3: Release Workflow Fixes
+
+#### Task 3.1: Fix Homebrew tap repository name in `release.yml`
+
+- **Files to modify:**
+  - `.github/workflows/release.yml` — Line 283
+- **Implementation details:**
+  - Change `repository: mschnecke/homebrew-lange` → `repository: mschnecke/homebrew-pisum-langue`
+  - This is a typo in the existing workflow
+- **Dependencies:** None
+- **Acceptance criteria:** Repository dispatch targets the correct tap repo
+
+#### Task 3.2: Add nuspec version update to `bump-version` job
+
+- **Files to modify:**
+  - `.github/workflows/release.yml` — `bump-version` job, after the tauri.conf.json update (around line 85)
+- **Implementation details:**
+  - Add sed command to update the nuspec version:
+    ```bash
+    # Update Chocolatey nuspec version
+    sed -i "s/<version>.*<\/version>/<version>$NEW_VERSION<\/version>/" packages/chocolatey/pisum-langue.nuspec
+    ```
+  - Add `packages/chocolatey/pisum-langue.nuspec` to the `git add` command on line 93
+- **Dependencies:** Task 1.1 (nuspec must exist)
+- **Acceptance criteria:** Version bump updates nuspec alongside package.json, Cargo.toml, and tauri.conf.json
+
+#### Task 3.3: Update release body installation instructions
+
+- **Files to modify:**
+  - `.github/workflows/release.yml` — Release body template (lines 126–163)
+- **Implementation details:**
+  - Update Homebrew section to match PRD requirement 6:
+    ```markdown
+    **macOS (Homebrew) - Recommended:**
+    ```bash
+    brew tap mschnecke/pisum-langue
+    brew install --cask pisum-langue
+    ```
+    ```
+  - Update Chocolatey section to match PRD requirement 11:
+    ```markdown
+    **Windows (Chocolatey):**
+    ```powershell
+    choco install pisum-langue --source https://www.myget.org/F/mschnecke/api/v3/index.json
+    ```
+    ```
+  - Current body uses `brew tap mschnecke/langue` and `brew install --cask langue` — these need to match the actual tap name
+  - Current body uses `choco source add` pattern — PRD specifies v3 endpoint with `--source` flag inline
+- **Dependencies:** None
+- **Acceptance criteria:** Release body shows correct install commands matching PRD requirements 6 and 11
+
+### Phase 4: Homebrew Tap Repository
+
+#### Task 4.1: Create `Casks/pisum-langue.rb` in tap repository
+
+- **Files to create (in tap repo):**
+  - `Casks/pisum-langue.rb` — Live cask formula (copy of template from Task 2.1)
+- **Implementation details:**
+  - Same content as `packages/homebrew/pisum-langue.rb` from the main repo
+  - This is the file Homebrew will read when users run `brew install --cask pisum-langue`
+- **Dependencies:** None
+- **Acceptance criteria:** `brew tap mschnecke/pisum-langue` succeeds and shows the cask
+
+#### Task 4.2: Create `update-cask.yml` workflow in tap repository
+
+- **Files to create (in tap repo):**
+  - `.github/workflows/update-cask.yml` — Dispatch event handler
+- **Implementation details:**
+  - Triggered by `repository_dispatch` with `event-type: update-cask`
+  - Receives version from `client-payload.version`
+  - Steps:
+    1. Checkout the tap repo
+    2. Download the `.pkg` from GitHub Releases:
+       ```bash
+       curl -L -o pisum-langue.pkg \
+         "https://github.com/mschnecke/langue/releases/download/v${VERSION}/Pisum.Langue_${VERSION}_aarch64.pkg"
+       ```
+    3. Compute SHA256:
+       ```bash
+       SHA256=$(shasum -a 256 pisum-langue.pkg | awk '{print $1}')
+       ```
+    4. Update `Casks/pisum-langue.rb` with new version and SHA256 using sed
+    5. Commit and push the change
+  - Reference: follow the same pattern from the `global-hotkey` tap repo workflow
+- **Dependencies:** Task 4.1
+- **Acceptance criteria:** Dispatch event triggers workflow that successfully updates the cask file and commits
+
+### Phase 5: Release Body Update
+
+> **Note:** This phase is already covered by Task 3.3. It's listed as a separate phase for clarity since the PRD's open question #3 explicitly calls it out, but the actual work is a single edit within Task 3.3.
+
+## 6. Data Model Changes
+
+No data model changes are required. This feature is entirely CI/CD and packaging.
+
+## 7. API Changes
+
+No API changes are required. This feature does not affect the Tauri IPC layer or any runtime behavior.
+
+## 8. Dependencies & Risks
+
+### External Dependencies
+| Dependency | Purpose | Risk |
+|-----------|---------|------|
+| MyGet.org | Chocolatey package hosting | Service availability; API key must be configured as `MYGET_API_KEY` secret |
+| `peter-evans/repository-dispatch@v2` | Triggers tap repo workflow | GitHub Action must remain available |
+| `HOMEBREW_TAP_TOKEN` secret | PAT with `actions:write` scope on tap repo | Must be created and kept valid |
+
+### Risks & Mitigations
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| MyGet push fails during release | Chocolatey package not updated | Workflow failure notification; can manually re-run job |
+| Homebrew dispatch doesn't trigger | Cask not updated | Check PAT permissions; workflow logs on tap repo |
+| SHA256 mismatch if assets re-uploaded | Install fails for users | Ensure `publish-release` completes before package jobs download artifacts |
+| Tap repo naming conflict | `brew tap` fails | Verify `homebrew-pisum-langue` follows Homebrew naming convention |
+
+### Assumptions
+- The `mschnecke/homebrew-pisum-langue` repository already exists
+- MyGet account and API key are already configured (per PRD open question #2)
+- `HOMEBREW_TAP_TOKEN` PAT will be created with appropriate scope
+
+## 9. Testing Strategy
+
+### Manual Verification (Post-First-Release)
+- Trigger a release via `workflow_dispatch` and verify:
+  - `bump-version` updates `pisum-langue.nuspec` alongside other version files
+  - `update-homebrew` dispatches to the correct tap repo
+  - `update-chocolatey` successfully packs and pushes to MyGet
+  - Tap repo's `update-cask.yml` runs, updates cask, and commits
+
+### End-to-End Install Tests
+- **macOS:** `brew tap mschnecke/pisum-langue && brew install --cask pisum-langue` installs successfully
+- **Windows:** `choco install pisum-langue --source https://www.myget.org/F/mschnecke/api/v3/index.json` installs successfully
+- **Upgrade:** After a second release, `brew upgrade pisum-langue` and `choco upgrade pisum-langue` pull the new version
+
+### Pre-Release Checks
+- `choco pack` in `packages/chocolatey/` produces a valid `.nupkg` locally
+- `pisum-langue.rb` cask syntax is valid (can lint with `brew audit --cask`)
+
+## 10. Requirement Traceability
+
+### Functional Requirements
+
+| PRD Ref | Requirement Summary | Task(s) | Notes |
+|---------|-------------------|---------|-------|
+| #1 | Separate `homebrew-pisum-langue` tap repo | — | Already created |
+| #2 | Cask formula at `Casks/pisum-langue.rb` installing `.pkg` | 4.1 | |
+| #3 | Cask targets aarch64 only, `depends_on macos: ">= :catalina"` | 2.1, 4.1 | |
+| #4 | Cask includes `zap` stanza for app data cleanup | 2.1, 4.1 | All four paths included |
+| #5 | Template cask at `packages/homebrew/pisum-langue.rb` | 2.1 | |
+| #6 | Install via `brew tap` + `brew install --cask` | 4.1, 3.3 | Instructions in release body |
+| #7 | Chocolatey nuspec at `packages/chocolatey/pisum-langue.nuspec` | 1.1 | |
+| #8 | Install script with `Install-ChocolateyPackage` + SHA256 | 1.2 | |
+| #9 | Uninstall script via registry lookup | 1.3 | |
+| #10 | Publish to MyGet NuGet feed | Existing workflow | Already in `release.yml` lines 330-337 |
+| #11 | Install via `choco install pisum-langue --source ...` | 1.1, 3.3 | Instructions in release body |
+| #12 | `update-homebrew` job triggers dispatch to tap repo | 3.1 | Fix repo name typo |
+| #13 | Tap workflow receives dispatch, updates cask | 4.2 | |
+| #14 | `update-chocolatey` job downloads MSI, updates files, packs, pushes | Existing workflow | Already in `release.yml` lines 287-337 |
+| #15 | `bump-version` updates nuspec version | 3.2 | |
+| #16 | `HOMEBREW_TAP_TOKEN` secret configured | — (manual) | Needs `actions:write` on tap repo |
+| #17 | `MYGET_API_KEY` secret configured | Existing | Already referenced in workflow |
+
+### User Stories
+
+| PRD Ref | User Story Summary | Implementing Tasks | Fully Covered? |
+|---------|-------------------|-------------------|----------------|
+| US-1 | macOS user installs via Homebrew | 2.1, 4.1, 4.2 | Yes |
+| US-2 | Windows user installs via Chocolatey | 1.1, 1.2, 1.3 | Yes |
+| US-3 | Maintainer: auto-publish on release | 3.1, 3.2, 4.2 | Yes |
+| US-4 | User upgrades via package manager | 4.2 (Homebrew), existing workflow (Chocolatey) | Yes |
+
+### Success Metrics
+
+| Metric | How the Plan Addresses It |
+|--------|--------------------------|
+| `brew install --cask pisum-langue` works | Tap repo with cask (Phase 4) + template (Phase 2) |
+| `choco install pisum-langue` works | Chocolatey package files (Phase 1) + existing workflow |
+| Release auto-updates both packages | Workflow fixes (Phase 3) + tap workflow (Phase 4) |
+| `brew upgrade` / `choco upgrade` works | Cask/nuspec version updates on each release |

--- a/docs/PRD-package-manager-distribution.md
+++ b/docs/PRD-package-manager-distribution.md
@@ -1,0 +1,94 @@
+# PRD: Package Manager Distribution (Homebrew & Chocolatey)
+
+## 1. Introduction/Overview
+
+Pisum Langue is currently distributed only via GitHub Releases as direct downloads (.pkg for macOS, .msi for Windows). Users must manually find, download, and install updates. This PRD covers adding Homebrew (macOS) and Chocolatey (Windows) package manager support, and wiring both into the existing release workflow so that every release automatically publishes updated packages.
+
+## 2. Goals
+
+- Enable macOS users to install and update Pisum Langue via `brew install --cask pisum-langue`
+- Enable Windows users to install and update Pisum Langue via `choco install pisum-langue`
+- Automate package publishing so every GitHub Release triggers Homebrew cask and Chocolatey package updates with zero manual steps
+- Follow the same proven patterns established in the `global-hotkey` reference repo
+
+## 3. User Stories
+
+- As a **macOS user**, I want to install Pisum Langue with `brew install --cask pisum-langue` so that I can use my familiar package manager and get updates through `brew upgrade`.
+- As a **Windows user**, I want to install Pisum Langue with `choco install pisum-langue` so that I can manage it alongside my other Chocolatey packages.
+- As a **maintainer**, I want package manager updates to happen automatically on release so that I don't have to manually update formulas, checksums, or package specs.
+- As a **user upgrading**, I want `brew upgrade` or `choco upgrade` to give me the latest version so that I stay current without visiting GitHub.
+
+## 4. Functional Requirements
+
+### Homebrew Cask
+
+1. A separate GitHub repository `mschnecke/homebrew-pisum-langue` must be created to serve as the Homebrew tap.
+2. The tap repository must contain a cask formula at `Casks/pisum-langue.rb` that installs the `.pkg` artifact from GitHub Releases.
+3. The cask must target Apple Silicon (aarch64) only, with `depends_on macos: ">= :catalina"`.
+4. The cask must include a `zap` stanza that removes application data from `~/Library/Application Support/com.pisum.langue`, `~/Library/Caches/com.pisum.langue`, `~/Library/Preferences/com.pisum.langue.plist`, and `~/Library/LaunchAgents/com.pisum.langue.plist`.
+5. A template cask file must exist in the main repo at `packages/homebrew/pisum-langue.rb` with placeholder values for version and SHA256.
+6. Users must be able to install with: `brew tap mschnecke/pisum-langue && brew install --cask pisum-langue`.
+
+### Chocolatey Package
+
+7. A Chocolatey package definition must exist at `packages/chocolatey/pisum-langue.nuspec` containing package metadata (id, version, title, authors, project URL, description, tags).
+8. An install script must exist at `packages/chocolatey/tools/chocolateyinstall.ps1` that downloads and silently installs the `.msi` from GitHub Releases using `Install-ChocolateyPackage` with SHA256 checksum verification.
+9. An uninstall script must exist at `packages/chocolatey/tools/chocolateyuninstall.ps1` that finds and removes the MSI via Windows Registry lookup.
+10. The Chocolatey package must be published to the MyGet NuGet feed at `https://www.myget.org/F/mschnecke/api/v3/index.json`.
+11. Users must be able to install with: `choco install pisum-langue --source https://www.myget.org/F/mschnecke/api/v3/index.json`.
+
+### Release Workflow Integration
+
+12. The existing `release.yml` must be updated to include an `update-homebrew` job that triggers a repository dispatch to `mschnecke/homebrew-pisum-langue` with the new version, passing the version string in the payload.
+13. The Homebrew tap repository must have a workflow that receives the dispatch event, downloads the `.pkg` artifact, computes the SHA256 checksum, updates the cask formula with the new version and hash, and commits the change.
+14. The existing `release.yml` must be updated to include an `update-chocolatey` job that:
+    - Runs on `windows-latest` after the `publish-release` job
+    - Downloads the built `.msi` artifact from the GitHub Release
+    - Computes the SHA256 checksum
+    - Updates `chocolateyinstall.ps1` with the new download URL and checksum
+    - Updates `pisum-langue.nuspec` with the new version
+    - Runs `choco pack` to create the `.nupkg`
+    - Pushes the package to MyGet using `choco push` with the `MYGET_API_KEY` secret
+15. The `bump-version` job in `release.yml` must also update the version in `packages/chocolatey/pisum-langue.nuspec` alongside the existing version files (package.json, Cargo.toml, tauri.conf.json).
+
+### Secrets & Configuration
+
+16. A `HOMEBREW_TAP_TOKEN` GitHub secret must be configured with a personal access token that has permission to trigger workflows on the `mschnecke/homebrew-pisum-langue` repository.
+17. A `MYGET_API_KEY` GitHub secret must be configured for publishing Chocolatey packages to the MyGet feed.
+
+## 5. Non-Goals (Out of Scope)
+
+- Not included: Publishing to the official Chocolatey Community Repository (chocolatey.org) — MyGet is sufficient for now
+- Not included: Intel (x64) macOS builds or universal binaries — only aarch64 is supported
+- Not included: Linux package managers (apt, snap, flatpak, AUR)
+- Not included: Auto-update mechanisms within the app itself (Tauri updater plugin)
+- Not included: Code signing for macOS or Windows installers
+- Not included: Creating a Homebrew formula (non-cask) — the app is a GUI application, so a cask is appropriate
+
+## 6. Design Considerations
+
+- The Homebrew tap naming convention follows `homebrew-{name}` so that `brew tap mschnecke/pisum-langue` maps to the `mschnecke/homebrew-pisum-langue` repo.
+- The Chocolatey package ID should be `pisum-langue` (lowercase, hyphenated) to follow Chocolatey naming conventions.
+- Installation instructions in the GitHub Release body (already generated by `release.yml`) should be updated to include the Homebrew and Chocolatey commands.
+
+## 7. Technical Considerations
+
+- **Reference implementation**: The `global-hotkey` repo (`/Users/mschnecke/workspace/github-global-hotkey`) has a working implementation of this exact pattern — use it as the primary reference for workflow structure, scripts, and package definitions.
+- **Workflow job dependencies**: `update-homebrew` and `update-chocolatey` must depend on `publish-release` to ensure artifacts are publicly available before package managers reference them.
+- **SHA256 checksums**: Both Homebrew and Chocolatey require SHA256 checksums of the installer artifacts. These must be computed in CI after downloading the built artifact — never hardcoded.
+- **MyGet feed**: The existing MyGet account (`mschnecke`) and feed should be reused. The Chocolatey install source URL for users is the v3 endpoint.
+- **Homebrew tap dispatch**: The dispatch event should include the version in the payload (e.g., `{ "version": "0.1.8" }`) so the tap workflow knows which release to pull.
+- **Asset naming**: macOS pkg is `Pisum.Langue_{version}_aarch64.pkg`, Windows MSI is `Pisum.Langue_{version}_x64_en-US.msi` — these names are determined by the existing Tauri build config and `create-macos-pkg.sh`.
+
+## 8. Success Metrics
+
+- `brew tap mschnecke/pisum-langue && brew install --cask pisum-langue` successfully installs the latest version on macOS (Apple Silicon)
+- `choco install pisum-langue --source https://www.myget.org/F/mschnecke/api/v3/index.json` successfully installs the latest version on Windows
+- A new release triggered via `release.yml` automatically updates both the Homebrew cask and Chocolatey package within the same workflow run, with no manual intervention
+- `brew upgrade pisum-langue` and `choco upgrade pisum-langue` correctly pull the new version after a release
+
+## 9. Open Questions
+
+- [x] Does the `mschnecke/homebrew-pisum-langue` tap repository already exist, or does it need to be created? -> already created
+- [x] Is the MyGet account and API key already configured, or do they need to be set up? -> already configured
+- [x] Should the GitHub Release body template be updated in this effort, or handled separately? -> the GitHub Release body template should be updated


### PR DESCRIPTION
Enhanced the release workflow to automate updates for Homebrew and Chocolatey package managers. Added support for version bumps in nuspec, fixed repository references, updated release instructions, and integrated automatic version updates for both package managers. This ensures seamless distribution and upgrade mechanisms for macOS and Windows users.